### PR TITLE
Hotfix: Include system prompts in Anthropic SDK API requests

### DIFF
--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -176,9 +176,9 @@ let editingTitleId = null;
         <p class="text-xs text-gray-400 z-20">System Role:</p>
       </div>
       {#if $conversations[$chosenConversationId]}
-      <textarea bind:value={$conversations[$chosenConversationId].assistantRole} {placeholder} class="bg-primary px-2 pt-1 pb-3 resize-none rounded focus:outline-none focus:outline-primary z-20"></textarea>
+      <textarea id="conversation-system-role" aria-label="Conversation system role" bind:value={$conversations[$chosenConversationId].assistantRole} {placeholder} class="bg-primary px-2 pt-1 pb-3 resize-none rounded focus:outline-none focus:outline-primary z-20"></textarea>
       {:else}
-      <textarea placeholder="Select a conversation or start a new one..." class="bg-primary px-2 pt-1 pb-3 resize-none rounded focus:outline-none focus:outline-primary z-20"></textarea>
+      <textarea id="conversation-system-role" aria-label="Conversation system role" placeholder="Select a conversation or start a new one..." class="bg-primary px-2 pt-1 pb-3 resize-none rounded focus:outline-none focus:outline-primary z-20"></textarea>
       {/if}
       
         <div class="flex flex-col h-40 my-2 flex-grow overflow-y-auto convo-container">

--- a/src/managers/conversationManager.ts
+++ b/src/managers/conversationManager.ts
@@ -222,10 +222,16 @@ export async function routeMessage(input: string, convId: string) {
         await sendDalleMessage(outgoingMessage, conversationIndex);
       } else if (isAnthropicModel(model)) {
         // Handle Claude/Anthropic models
+        // Add system message for Anthropic (SDK will extract it separately)
+        const systemMessage: ChatCompletionRequestMessage = {
+          role: "system",
+          content: conversation.assistantRole
+        };
+        const anthropicMessages = [systemMessage, ...outgoingMessage];
         const config = { model };
         console.log(`Routing Claude model ${model} to Anthropic service`);
         // For now, use streaming by default for Claude models
-        await streamAnthropicMessage(outgoingMessage, conversationIndex, config);
+        await streamAnthropicMessage(anthropicMessages, conversationIndex, config);
       } else {
         // Default case for regular messages if no specific keywords are found in the model string
         const config = { model, reasoningEffort: perConv.reasoningEffort, verbosity: perConv.verbosity, summary: perConv.summary };

--- a/tests-e2e/live/anthropic-system-prompt.spec.ts
+++ b/tests-e2e/live/anthropic-system-prompt.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * E2E Test: Anthropic System Prompt Integration
+ *
+ * Verifies that system prompts (both default and custom) are correctly
+ * sent to the Anthropic API via the SDK integration.
+ *
+ * TDD Test - Written before implementation fix
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bootstrapBothProviders,
+  operateQuickSettings,
+  sendMessage,
+  waitForAssistantDone,
+  setConversationSystemPrompt
+} from './helpers';
+
+test.describe('Anthropic System Prompt Integration', () => {
+
+  test('should include default system prompt in Anthropic API request', async ({ page }) => {
+    // Capture API requests to Anthropic
+    const anthropicRequests: any[] = [];
+
+    page.on('request', async (request) => {
+      if (request.url().includes('api.anthropic.com/v1/messages')) {
+        try {
+          const postData = request.postDataJSON();
+          anthropicRequests.push(postData);
+
+          if (process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+            console.log('[DEBUG] Anthropic API Request captured:', JSON.stringify(postData, null, 2));
+          }
+        } catch (e) {
+          console.error('Failed to parse Anthropic request:', e);
+        }
+      }
+    });
+
+    // Setup API keys
+    await page.goto('/');
+    await bootstrapBothProviders(page);
+
+    // Select Claude model
+    await operateQuickSettings(page, {
+      model: /claude-3-haiku-20240307/i,
+      closeAfter: true
+    });
+
+    // Send a message
+    await sendMessage(page, 'Think hard about Why Ruby is loved by many, but losing the adoption wars.');
+
+    // Wait for response
+    await waitForAssistantDone(page, { timeout: 30000 });
+
+    // Verify API request was captured
+    expect(anthropicRequests.length).toBeGreaterThan(0);
+
+    const request = anthropicRequests[0];
+
+    // Verify structure
+    expect(request).toHaveProperty('model');
+    expect(request).toHaveProperty('messages');
+    expect(request.messages).toBeInstanceOf(Array);
+
+    // CRITICAL: Verify system prompt is present
+    // The default system prompt should be included
+    expect(request).toHaveProperty('system');
+    expect(typeof request.system).toBe('string');
+    expect(request.system.length).toBeGreaterThan(0);
+
+    if (process.env.DEBUG_E2E === '1' || process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+      console.log('✓ System prompt present in Anthropic request');
+      console.log('  System prompt:', request.system);
+    }
+  });
+
+  test('should include custom conversation system prompt in Anthropic API request', async ({ page }) => {
+    const anthropicRequests: any[] = [];
+    const customSystemPrompt = 'You are a Ruby programming expert. Provide detailed technical analysis.';
+
+    page.on('request', async (request) => {
+      if (request.url().includes('api.anthropic.com/v1/messages')) {
+        try {
+          const postData = request.postDataJSON();
+          anthropicRequests.push(postData);
+
+          if (process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+            console.log('[DEBUG] Anthropic API Request with custom prompt:', JSON.stringify(postData, null, 2));
+          }
+        } catch (e) {
+          console.error('Failed to parse Anthropic request:', e);
+        }
+      }
+    });
+
+    await page.goto('/');
+    await bootstrapBothProviders(page);
+
+    // Change the conversation-level system prompt using helper
+    await setConversationSystemPrompt(page, customSystemPrompt);
+
+    // Select Claude model
+    await operateQuickSettings(page, {
+      model: /claude-3-haiku-20240307/i,
+      closeAfter: true
+    });
+
+    // Send a message
+    await sendMessage(page, 'Explain Ruby metaprogramming');
+
+    // Wait for response
+    await waitForAssistantDone(page, { timeout: 30000 });
+
+    // Verify API request includes custom system prompt
+    expect(anthropicRequests.length).toBeGreaterThan(0);
+
+    const request = anthropicRequests[0];
+
+    // Verify custom system prompt is present
+    expect(request).toHaveProperty('system');
+    expect(request.system).toBe(customSystemPrompt);
+
+    if (process.env.DEBUG_E2E === '1' || process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+      console.log('✓ Custom conversation system prompt present in Anthropic request');
+      console.log('  Expected:', customSystemPrompt);
+      console.log('  Actual:', request.system);
+    }
+  });
+
+  test('should send system prompt with reasoning models (Claude Sonnet 4)', async ({ page }) => {
+    const anthropicRequests: any[] = [];
+
+    page.on('request', async (request) => {
+      if (request.url().includes('api.anthropic.com/v1/messages')) {
+        try {
+          const postData = request.postDataJSON();
+          anthropicRequests.push(postData);
+
+          if (process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+            console.log('[DEBUG] Anthropic reasoning model request:', JSON.stringify(postData, null, 2));
+          }
+        } catch (e) {
+          console.error('Failed to parse Anthropic request:', e);
+        }
+      }
+    });
+
+    await page.goto('/');
+    await bootstrapBothProviders(page);
+
+    // Select Claude Sonnet 4 (reasoning model)
+    await operateQuickSettings(page, {
+      model: /claude-sonnet-4-5-20250929/i,
+      closeAfter: true
+    });
+
+    // Send a message
+    await sendMessage(page, 'What is 2+2?');
+
+    // Wait for response
+    await waitForAssistantDone(page, { timeout: 60000 });
+
+    // Verify request structure
+    expect(anthropicRequests.length).toBeGreaterThan(0);
+
+    const request = anthropicRequests[0];
+
+    // Verify system prompt is present
+    expect(request).toHaveProperty('system');
+    expect(request.system).toBeTruthy();
+
+    // Verify thinking configuration for reasoning model
+    expect(request).toHaveProperty('thinking');
+    expect(request.thinking).toHaveProperty('type', 'enabled');
+    expect(request.thinking).toHaveProperty('budget_tokens');
+
+    if (process.env.DEBUG_E2E === '1' || process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+      console.log('✓ System prompt present with reasoning model');
+      console.log('  System prompt:', request.system);
+      console.log('  Thinking config:', request.thinking);
+    }
+  });
+});

--- a/tests-e2e/live/helpers.ts
+++ b/tests-e2e/live/helpers.ts
@@ -1627,3 +1627,21 @@ export async function getModelDropdownState(
   return result;
 }
 
+/**
+ * Sets the system role/prompt for the current conversation
+ * @param page - Playwright Page object
+ * @param systemPrompt - The system prompt text to set
+ */
+export async function setConversationSystemPrompt(page: Page, systemPrompt: string): Promise<void> {
+  const systemRoleTextarea = page.locator('#conversation-system-role');
+  await expect(systemRoleTextarea).toBeVisible({ timeout: 5000 });
+  await systemRoleTextarea.click();
+  await systemRoleTextarea.fill(systemPrompt);
+
+  // Verify the value was set
+  const actualValue = await systemRoleTextarea.inputValue();
+  if (actualValue !== systemPrompt) {
+    throw new Error(`Failed to set system prompt. Expected: "${systemPrompt}", Got: "${actualValue}"`);
+  }
+}
+

--- a/tests-e2e/live/openai-system-prompt.spec.ts
+++ b/tests-e2e/live/openai-system-prompt.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * E2E Test: OpenAI System Prompt Integration
+ *
+ * Verifies that system prompts (both default and custom) are correctly
+ * sent to the OpenAI API via the Responses API integration.
+ *
+ * Parallel test to anthropic-system-prompt.spec.ts
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  bootstrapLiveAPI,
+  operateQuickSettings,
+  sendMessage,
+  waitForAssistantDone,
+  setConversationSystemPrompt
+} from './helpers';
+
+test.describe('OpenAI System Prompt Integration', () => {
+
+  test('should include default system prompt in OpenAI API request', async ({ page }) => {
+    const openaiRequests: any[] = [];
+
+    page.on('request', async (request) => {
+      if (request.url().includes('api.openai.com/v1/responses')) {
+        try {
+          const postData = request.postDataJSON();
+          openaiRequests.push(postData);
+
+          if (process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+            console.log('[DEBUG] OpenAI API Request captured:', JSON.stringify(postData, null, 2));
+          }
+        } catch (e) {
+          console.error('Failed to parse OpenAI request:', e);
+        }
+      }
+    });
+
+    await page.goto('/');
+    await bootstrapLiveAPI(page, 'OpenAI');
+
+    // Select a GPT model (non-reasoning for speed)
+    await operateQuickSettings(page, {
+      model: /gpt-3\.5-turbo/i,
+      closeAfter: true
+    });
+
+    // Send a message
+    await sendMessage(page, 'What is 2+2?');
+
+    // Wait for response
+    await waitForAssistantDone(page, { timeout: 30000 });
+
+    // Verify API request was captured
+    expect(openaiRequests.length).toBeGreaterThan(0);
+
+    const request = openaiRequests[0];
+
+    // Verify structure
+    expect(request).toHaveProperty('input');
+    expect(Array.isArray(request.input)).toBe(true);
+
+    // The default system prompt should be in the input array as first message
+    // OpenAI Responses API uses structured content format
+    const systemMessage = request.input.find((msg: any) => msg.role === 'system');
+    expect(systemMessage).toBeDefined();
+    expect(systemMessage.content).toBeTruthy();
+    expect(Array.isArray(systemMessage.content)).toBe(true);
+
+    // Extract text from content array
+    const textContent = systemMessage.content.find((c: any) => c.type === 'input_text');
+    expect(textContent).toBeDefined();
+    expect(textContent.text).toBeTruthy();
+    expect(textContent.text.length).toBeGreaterThan(0);
+
+    if (process.env.DEBUG_E2E === '1' || process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+      console.log('✓ System prompt present in OpenAI request');
+      console.log('  System prompt:', textContent.text);
+    }
+  });
+
+  test('should include custom conversation system prompt in OpenAI API request', async ({ page }) => {
+    const openaiRequests: any[] = [];
+    const customSystemPrompt = 'You are a mathematics expert. Provide precise numerical answers.';
+
+    page.on('request', async (request) => {
+      if (request.url().includes('api.openai.com/v1/responses')) {
+        try {
+          const postData = request.postDataJSON();
+          openaiRequests.push(postData);
+
+          if (process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+            console.log('[DEBUG] OpenAI API Request with custom prompt:', JSON.stringify(postData, null, 2));
+          }
+        } catch (e) {
+          console.error('Failed to parse OpenAI request:', e);
+        }
+      }
+    });
+
+    await page.goto('/');
+    await bootstrapLiveAPI(page, 'OpenAI');
+
+    // Change the conversation-level system prompt using helper
+    await setConversationSystemPrompt(page, customSystemPrompt);
+
+    // Select a GPT model
+    await operateQuickSettings(page, {
+      model: /gpt-3\.5-turbo/i,
+      closeAfter: true
+    });
+
+    // Send a message
+    await sendMessage(page, 'What is the square root of 144?');
+
+    // Wait for response
+    await waitForAssistantDone(page, { timeout: 30000 });
+
+    // Verify API request includes custom system prompt
+    expect(openaiRequests.length).toBeGreaterThan(0);
+
+    const request = openaiRequests[0];
+
+    // Find system message in input array
+    const systemMessage = request.input.find((msg: any) => msg.role === 'system');
+    expect(systemMessage).toBeDefined();
+
+    // Extract text from structured content
+    const textContent = systemMessage.content.find((c: any) => c.type === 'input_text');
+    expect(textContent).toBeDefined();
+    expect(textContent.text).toBe(customSystemPrompt);
+
+    if (process.env.DEBUG_E2E === '1' || process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+      console.log('✓ Custom conversation system prompt present in OpenAI request');
+      console.log('  Expected:', customSystemPrompt);
+      console.log('  Actual:', textContent.text);
+    }
+  });
+
+  test('should send system prompt with reasoning models (GPT-5 nano)', async ({ page }) => {
+    const openaiRequests: any[] = [];
+
+    page.on('request', async (request) => {
+      if (request.url().includes('api.openai.com/v1/responses')) {
+        try {
+          const postData = request.postDataJSON();
+          openaiRequests.push(postData);
+
+          if (process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+            console.log('[DEBUG] OpenAI reasoning model request:', JSON.stringify(postData, null, 2));
+          }
+        } catch (e) {
+          console.error('Failed to parse OpenAI request:', e);
+        }
+      }
+    });
+
+    await page.goto('/');
+    await bootstrapLiveAPI(page, 'OpenAI');
+
+    // Select a reasoning model
+    await operateQuickSettings(page, {
+      model: /gpt-5-nano/i,
+      closeAfter: true
+    });
+
+    // Send a message
+    await sendMessage(page, 'What is 2+2?');
+
+    // Wait for response
+    await waitForAssistantDone(page, { timeout: 60000 });
+
+    // Verify request structure
+    expect(openaiRequests.length).toBeGreaterThan(0);
+
+    const request = openaiRequests[0];
+
+    // Verify system prompt is present
+    const systemMessage = request.input.find((msg: any) => msg.role === 'system');
+    expect(systemMessage).toBeDefined();
+    expect(systemMessage.content).toBeTruthy();
+
+    // Extract text from structured content
+    const textContent = systemMessage.content.find((c: any) => c.type === 'input_text');
+    expect(textContent).toBeDefined();
+    expect(textContent.text).toBeTruthy();
+
+    // Verify reasoning configuration (OpenAI Responses API format)
+    expect(request).toHaveProperty('reasoning');
+    expect(request.reasoning).toHaveProperty('effort');
+
+    if (process.env.DEBUG_E2E === '1' || process.env.DEBUG_E2E === '2' || process.env.DEBUG_E2E === '3') {
+      console.log('✓ System prompt present with reasoning model');
+      console.log('  System prompt:', textContent.text);
+      console.log('  Reasoning config:', request.reasoning);
+    }
+  });
+});


### PR DESCRIPTION
## Issue
System prompts (both default and conversation-specific) were not being sent to the Anthropic API, causing all requests to be made without the user-configured context.

## Root Cause
The `routeMessage()` function in `conversationManager.ts` was not including the conversation's `assistantRole` (system prompt) when routing to Anthropic models, unlike OpenAI routing which correctly includes it.

## Solution
Add system message to the message array before calling `streamAnthropicMessage()`. The Anthropic SDK's `convertToSDKFormatWithSystem()` properly extracts and formats it as the top-level `system` parameter per Anthropic API specification.

## Changes
- ✅ Fixed Anthropic routing to include system prompts
- ✅ Added semantic identifiers to system role textarea
- ✅ Created helper function for setting conversation system prompts
- ✅ Added comprehensive E2E test coverage (6 tests: 3 Anthropic + 3 OpenAI)

## Testing
All new tests pass:
- Default system prompts work correctly
- Custom conversation system prompts work correctly  
- System prompts work with reasoning models (Claude Sonnet 4, GPT-5 nano)

## Impact
- **Critical fix** for Anthropic API integration
- No breaking changes
- Improved test coverage and UI accessibility

🤖 Generated with [Claude Code](https://claude.ai/code)